### PR TITLE
fix typo

### DIFF
--- a/sphero-server/index.html
+++ b/sphero-server/index.html
@@ -25,7 +25,7 @@
         <section>
           <ul>
             <li><a href="http://co.mozillafactory.org/post/136024688635/sphero%E3%82%92%E3%82%B9%E3%82%BF%E3%83%83%E3%83%95%E3%81%A7%E8%A7%A6%E3%81%A3%E3%81%A6%E3%81%84%E3%81%BE%E3%81%99">コモジラ研究所 『Spheroをスタッフで触っています！』</a></li>
-            <li><a href="https://github.com/shundroid/Sphero-Server/wiki">Spher-Server Wiki</a></li>
+            <li><a href="https://github.com/shundroid/Sphero-Server/wiki">Sphero-Server Wiki</a></li>
           </ul>
         </section>
       </article>

--- a/sphero-server/index.jade
+++ b/sphero-server/index.jade
@@ -34,6 +34,6 @@ html(lang="en")
                 | コモジラ研究所 『Spheroをスタッフで触っています！』
             li
               a(href="https://github.com/shundroid/Sphero-Server/wiki")
-                | Spher-Server Wiki
+                | Sphero-Server Wiki
       footer
         | created by Shundroid


### PR DESCRIPTION
お疲れ様です。
細かいところですが、「Sphero」が「Spher」になっていたので修正しました。
せっかくなのでプルリク送ります。